### PR TITLE
Version bump for many plugins, update copyright date

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache DataSketches Hive
-Copyright 2022 The Apache Software Foundation
+Copyright 2024 The Apache Software Foundation
 
 Copyright 2015-2018 Yahoo Inc.
 Copyright 2019-2021 Verizon Media

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@ under the License.
 
   <groupId>org.apache.datasketches</groupId>
   <artifactId>datasketches-hive</artifactId>
-  <version>1.3.0-SNAPSHOT</version>
+  <version>2.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>${project.artifactId}</name>
@@ -106,25 +106,25 @@ under the License.
     <!-- org.codehaus plugins -->
     <!-- used for strict profile testing-->
     <plexus-compiler-javac-errorprone.version>2.8.5</plexus-compiler-javac-errorprone.version>
-    <versions-maven-plugin.version>2.8.1</versions-maven-plugin.version>
+    <versions-maven-plugin.version>2.16.2</versions-maven-plugin.version>
 
     <!--  Maven Plugins -->
-    <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version> <!-- overrides parent -->
-    <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version> <!-- overrides parent -->
-    <maven-deploy-plugin.version>3.0.0-M2</maven-deploy-plugin.version> <!-- overrides parent -->
-    <maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version> <!-- overrides parent -->
-    <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version> <!-- overrides parent -->
-    <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version> <!-- overrides parent -->
-    <maven-javadoc-plugin.version>3.3.1</maven-javadoc-plugin.version> <!-- overrides parent -->
-    <maven-release-plugin.version>3.0.0-M4</maven-release-plugin.version> <!-- overrides parent -->
+    <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version> <!-- overrides parent -->
+    <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version> <!-- overrides parent -->
+    <maven-deploy-plugin.version>3.1.2</maven-deploy-plugin.version> <!-- overrides parent -->
+    <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version> <!-- overrides parent -->
+    <maven-gpg-plugin.version>3.2.4</maven-gpg-plugin.version> <!-- overrides parent -->
+    <maven-jar-plugin.version>3.4.1</maven-jar-plugin.version> <!-- overrides parent -->
+    <maven-javadoc-plugin.version>3.7.0</maven-javadoc-plugin.version> <!-- overrides parent -->
+    <maven-release-plugin.version>3.0.1</maven-release-plugin.version> <!-- overrides parent -->
     <maven-remote-resources-plugin.version>[1.7.0,)</maven-remote-resources-plugin.version> <!-- overrides parent -->
-    <maven-source-plugin.version>3.2.1</maven-source-plugin.version> <!-- overrides parent -->
-    <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version> <!-- overrides parent -->
+    <maven-source-plugin.version>3.3.1</maven-source-plugin.version> <!-- overrides parent -->
+    <maven-surefire-plugin.version>3.3.0</maven-surefire-plugin.version> <!-- overrides parent -->
     <maven-toolchains-plugin.version>3.0.0</maven-toolchains-plugin.version>
     <!-- Apache Plugins -->
-    <apache-rat-plugin.version>0.13</apache-rat-plugin.version> <!-- overrides parent -->
+    <apache-rat-plugin.version>0.16.1</apache-rat-plugin.version> <!-- overrides parent -->
     <!-- org.jacoco Maven Plugins -->
-    <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
+    <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
     <!-- org.eluder Maven Plugins -->
     <coveralls-repo-token></coveralls-repo-token>
     <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>


### PR DESCRIPTION
Also set version to that of potential next release.

I plan to use this as the base for a 2.0.0 release, which I'll do by fixing that version in a 2.0.X branch after this is approved.